### PR TITLE
[fix-set-env] Use new command to set env variables

### DIFF
--- a/codeclimate-env/entrypoint.sh
+++ b/codeclimate-env/entrypoint.sh
@@ -1,2 +1,2 @@
-echo "::set-env name=BRANCH_NAME::${GITHUB_REF#refs/heads/}"
-echo "::set-env name=GIT_COMMIT_SHA::${GITHUB_SHA}"
+echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+echo "GIT_COMMIT_SHA=${GITHUB_SHA}" >> $GITHUB_ENV

--- a/set-logs-url/entrypoint.sh
+++ b/set-logs-url/entrypoint.sh
@@ -5,5 +5,5 @@ set -e
 
 JOB_ID=$(curl -s -L -H "Authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs | jq ".jobs[] | select(.name == \"${JOB_NAME}\") | .id")
 LOGS_URL="https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}/checks/${JOB_ID}/logs"
-echo "::set-env name=DREIPOL_JOB_ID::${JOB_ID}"
-echo "::set-env name=DREIPOL_LOGS_URL::${LOGS_URL}"
+echo "DREIPOL_JOB_ID=${JOB_ID}" >> $GITHUB_ENV
+echo "DREIPOL_LOGS_URL=${LOGS_URL}" >> $GITHUB_ENV

--- a/slugify/entrypoint.sh
+++ b/slugify/entrypoint.sh
@@ -12,7 +12,7 @@ short_sha(){
         | cut -c1-8
 }
 
-echo ::set-env name=GITHUB_REF_SLUG::"$(slug_ref "$GITHUB_REF")"
-echo ::set-env name=GITHUB_HEAD_REF_SLUG::"$(slug_ref "$GITHUB_HEAD_REF")"
-echo ::set-env name=GITHUB_BASE_REF_SLUG::"$(slug_ref "$GITHUB_BASE_REF")"
-echo ::set-env name=GITHUB_SHA_SHORT::"$(short_sha "$GITHUB_SHA")"
+echo "GITHUB_REF_SLUG=$(slug_ref $GITHUB_REF)" >> $GITHUB_ENV
+echo "GITHUB_HEAD_REF_SLUG=$(slug_ref $GITHUB_HEAD_REF)" >> $GITHUB_ENV
+echo "GITHUB_BASE_REF_SLUG=$(slug_ref $GITHUB_BASE_REF)" >> $GITHUB_ENV
+echo "GITHUB_SHA_SHORT=$(short_sha $GITHUB_SHA)" >> $GITHUB_ENV


### PR DESCRIPTION
See:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files