### PR TITLE
[build_in_subdirectory] Add subdirectory env variable

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if [ -n "${DOCKER_SUBDIRECTORY}" ]; then
+  cd "$DOCKER_SUBDIRECTORY" || exit
+fi
+
 if [ -n "${GCP_SERVICEACCOUNT_KEY}" ]; then
   echo "Logging into gcr.io with GCLOUD_SERVICE_ACCOUNT_KEY..."
   echo ${GCP_SERVICEACCOUNT_KEY} | base64 -d > /tmp/key.json


### PR DESCRIPTION
can be used in case the dockerfile is in a subdirectory. This allows us to use multiple Dockerfiles in the same repo (eg. mono repos) without changing our deployment workflow.