### PR TITLE
Feat/bypass docker build with a custom cache tag bust (SSG)

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -16,12 +16,22 @@ if [ -n "${WORKING_DIRECTORY}" ]; then
   cd $WORKING_DIRECTORY
 fi
 
+if [ -n "${CUSTOM_CACHE_TAG}" ]; then
+    # This is a "Custom Cache Tag Buster": The current setup only allows "code-based" SHA-Tagged Docker builds.
+    # In case of Static Site Generation, the SHA can be "stale". We need to bust it in order to re-generate.
+    IMAGE_TAG="${CUSTOM_CACHE_TAG}"
+    echo "Using CUSTOM_CACHE_TAG: $IMAGE_TAG"
+else
+    IMAGE_TAG="$GITHUB_SHA"
+    echo "Using GITHUB_SHA: $IMAGE_TAG"
+fi
 
-if ! docker pull $GCR_IMAGE:$GITHUB_SHA;
+
+if ! docker pull $GCR_IMAGE:$IMAGE_TAG;
 then
   docker buildx create --driver docker-container --use --name BUILDX_BUILDER
   docker buildx build \
-      -t $GCR_IMAGE:$GITHUB_SHA \
+      -t $GCR_IMAGE:$IMAGE_TAG \
       --output type=docker \
       --build-arg PROJECT_NAME=$PROJECT_NAME \
       --build-arg GIT_REV=$GCR_IMAGE:$GITHUB_SHA \


### PR DESCRIPTION
### What's new:
- A `CUSTOM_CACHE_TAG` param which we would need in order to run a new docker build when there's already a docker image with the current's Git SHA of the HEAD. We need this in case of Static Site Generation when trigger builds from within DatoCMS.
- Usage together with DatoCMS would probably push a Custom tag like `DatoBuild-${NOW}` or something with a uniqueness to it, to be defined. Unfortunately the custom build trigger from within DatoCMS does not include a hash from their side to see if the build is actually necessary 😢 Also, no `build_id` or anything we can pass in the payload. We need to create uniqueness from within the github action ourselves.

Please kick this back to me if it does not make any sense at all. Also, I could make a `build-ssg/no-cache` action or so that just bypasses the check completely to not interfere with the current `build` spec. Let me know what you think!